### PR TITLE
Develop

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -25,8 +25,8 @@ class Tag(models.Model):
 
 class Product(models.Model):
     CATEGORY = (
-        ('Indoor', 'Indoor'),
-        ('Out Door', 'Out Door')
+        ('indoor', 'Indoor'),
+        ('outdoor', 'Out Door')
     )
 
     name = models.CharField(max_length=200, null=True)
@@ -42,9 +42,9 @@ class Product(models.Model):
 
 class Order(models.Model):
     STATUS = (
-        ('Pending', 'Pending'),
-        ('Out for delivery', 'Out for delivery'),
-        ('Delivered', 'Delivered')
+        ('pending', 'Pending'),
+        ('out_for_delivery', 'Out for delivery'),
+        ('delivered', 'Delivered')
     )
 
     customer = models.ForeignKey(

--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -38,7 +38,7 @@
 			<table class="table table-sm">
 				<tr>
 					<th>Product</th>
-					<th>Date Orderd</th>
+					<th>Date Ordered</th>
 					<th>Status</th>
 					<th>Update</th>
 					<th>Remove</th>


### PR DESCRIPTION
###  First commit
Fix for typo on dashboard template
### Second commit
I edited the first element in each choice tuple.
_Reason_: For each choice tuple, the first element will be set in the database and the second one will be displayed.
It will be easier for a developer to make queries through the shell/terminal if the value set in the DB maintains a consistent casing and doesn't have white spaces.
_Example_:
```
 from account.models import Product, Order
          p1 = Products.objects.get(category="outdoor")
          o1 = Order.objects.get(status="out_for_delivery")
```

would be relatively easier as opposed to

```
from account.models import Product, Order
    p1 = Products.objects.get(category="Out Door")
    o1 = Order.objects.get(status="Out for delivery")
```
With this refactor, the value in the database would be "outdoor" but the value displayed to a user through a template, or in the admin dashboard will be "Out Door". Hence easier DB queries while maintaining good frontend casing